### PR TITLE
feat: Improve ProfileImage performance with loading attributes

### DIFF
--- a/src/components/ProfileImage.astro
+++ b/src/components/ProfileImage.astro
@@ -5,9 +5,10 @@ import frankHeadshot from '../assets/frank-headshot.png';
 interface Props {
   className?: string;
   priority?: boolean;
+  loading?: 'lazy' | 'eager';
 }
 
-const { className = "", priority = false } = Astro.props;
+const { className = "", priority = false, loading = 'lazy' } = Astro.props;
 ---
 
 <div class={`relative overflow-hidden rounded-full ${className}`}>
@@ -21,7 +22,9 @@ const { className = "", priority = false } = Astro.props;
     quality="mid"
     formats={['avif', 'webp']}
     priority={priority}
+    loading={loading}
     class="w-full h-full object-cover"
+    decoding="async"
   />
 </div>
 


### PR DESCRIPTION
### **User description**
## Description

This PR adds performance improvements to the ProfileImage component by:
- Adding a `loading` prop that accepts 'lazy' or 'eager' (defaults to lazy)
- Adding `decoding='async'` attribute for better browser performance
- These changes help improve Core Web Vitals scores

## Testing
- Verified the image still loads correctly
- Checked that lazy loading works as expected
- Confirmed no visual regressions

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update


___

### **PR Type**
Enhancement


___

### **Description**
- Add `loading` prop with lazy/eager options to ProfileImage

- Add `decoding='async'` attribute for better browser performance

- Improve Core Web Vitals scores through optimized image loading


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ProfileImage Props"] --> B["loading prop (lazy/eager)"]
  A --> C["decoding='async'"]
  B --> D["Improved Core Web Vitals"]
  C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ProfileImage.astro</strong><dd><code>Add loading and decoding attributes for performance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/ProfileImage.astro

<ul><li>Added <code>loading</code> prop to Props interface with 'lazy' or 'eager' options<br> <li> Set default value for <code>loading</code> prop to 'lazy'<br> <li> Added <code>loading</code> attribute to Image component<br> <li> Added <code>decoding="async"</code> attribute to Image component</ul>


</details>


  </td>
  <td><a href="https://github.com/SpacePlushy/portfolio/pull/6/files#diff-f700d9fca7f6683fb642255b93fefacb4f8feb77ea7814cc921d9e6ddda4a730">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

